### PR TITLE
fix: core service heartbeat handling and island change publishing

### DIFF
--- a/core/src/service.ts
+++ b/core/src/service.ts
@@ -42,7 +42,11 @@ export async function main(program: Lifecycle.EntryPointParameters<AppComponents
       const updates = await engine.flush()
       for (const [peerId, update] of updates) {
         if (update.action === 'changeTo') {
-          const island = engine.getIsland(update.islandId)!
+          const island = engine.getIsland(update.islandId)
+          if (!island) {
+            logger.warn(`Island ${update.islandId} not found for peer ${peerId}, skipping update`)
+            continue
+          }
           logger.debug(`Publishing island change for ${peerId}`)
           publisher.onChangeToIsland(peerId, island, update)
         } else if (update.action === 'leave') {
@@ -54,7 +58,7 @@ export async function main(program: Lifecycle.EntryPointParameters<AppComponents
       logger.error(err)
     } finally {
       const flushElapsed = Date.now() - startTime
-      setTimeout(loop, Math.max(flushFrequency * 1000 - flushElapsed), 1) // At least 1 ms between flushes
+      setTimeout(loop, Math.max(flushFrequency * 1000 - flushElapsed, 1)) // At least 1 ms between flushes
     }
   }
 
@@ -69,6 +73,7 @@ export async function main(program: Lifecycle.EntryPointParameters<AppComponents
 
     try {
       const id = message.subject.split('.')[1]
+      lastPeerHeartbeats.delete(id)
       engine.onPeerDisconnected(id)
     } catch (err: any) {
       logger.error(`cannot process peer_connect message ${err.message}`)
@@ -83,6 +88,7 @@ export async function main(program: Lifecycle.EntryPointParameters<AppComponents
 
     try {
       const id = message.subject.split('.')[1]
+      lastPeerHeartbeats.delete(id)
       engine.onPeerDisconnected(id)
     } catch (err: any) {
       logger.error(`cannot process peer_disconnect message ${err.message}`)
@@ -98,16 +104,25 @@ export async function main(program: Lifecycle.EntryPointParameters<AppComponents
     try {
       const id = message.subject.split('.')[1]
       const decodedMessage = Heartbeat.decode(message.data)
-      const position = decodedMessage.position!
+      const position = decodedMessage.position
+      if (!position) {
+        return
+      }
 
       lastPeerHeartbeats.set(id, Date.now())
-      engine.onPeerPositionsUpdate([
-        {
-          id,
-          position: [position.x, position.y, position.z],
-          preferedIslandId: decodedMessage.desiredRoom
-        }
-      ])
+
+      // Only include preferedIslandId when desiredRoom is explicitly set.
+      // The engine uses 'preferedIslandId' in change to decide whether to update
+      // the preference. Including the key with undefined clears any existing
+      // preference on every heartbeat, making preferences effectively single-use.
+      const change: { id: string; position: [number, number, number]; preferedIslandId?: string } = {
+        id,
+        position: [position.x, position.y, position.z]
+      }
+      if (decodedMessage.desiredRoom) {
+        change.preferedIslandId = decodedMessage.desiredRoom
+      }
+      engine.onPeerPositionsUpdate([change])
     } catch (err: any) {
       logger.error(`cannot process heartbeat message ${err.message}`)
     }

--- a/core/test/unit/service-heartbeat.spec.ts
+++ b/core/test/unit/service-heartbeat.spec.ts
@@ -1,0 +1,176 @@
+import { Heartbeat } from '@dcl/protocol/out-js/decentraland/kernel/comms/v3/archipelago.gen'
+import { createLocalNatsComponent } from '@well-known-components/nats-component'
+import { INatsComponent } from '@well-known-components/nats-component/dist/types'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { createLogComponent } from '@well-known-components/logger'
+import { createTestMetricsComponent } from '@well-known-components/metrics'
+import { metricDeclarations } from '../../src/metrics'
+import { createArchipelagoEngine } from '../../src/adapters/engine'
+import { Engine } from '../../src/types'
+
+/**
+ * These tests verify the service loop behavior for heartbeat tracking and peer
+ * disconnect/reconnect scenarios. They replicate the logic from core/src/service.ts
+ * without starting the full lifecycle.
+ */
+describe('service heartbeat tracking', () => {
+  let engine: Engine
+  let nats: INatsComponent
+  let lastPeerHeartbeats: Map<string, number>
+  const CHECK_HEARTBEAT_INTERVAL = 60000
+
+  beforeEach(async () => {
+    nats = await createLocalNatsComponent()
+    const config = createConfigComponent({ LOG_LEVEL: 'INFO' })
+    const logs = await createLogComponent({ config })
+    const metrics = createTestMetricsComponent(metricDeclarations)
+
+    engine = createArchipelagoEngine({
+      components: { logs, metrics },
+      joinDistance: 64,
+      leaveDistance: 80,
+      transport: {
+        name: 'test',
+        maxIslandSize: 200,
+        getConnectionStrings(userIds: string[], roomId: string): Promise<Record<string, string>> {
+          const connStrs: Record<string, string> = {}
+          for (const userId of userIds) {
+            connStrs[userId] = `test:${roomId}.${userId}`
+          }
+          return Promise.resolve(connStrs)
+        }
+      }
+    })
+
+    lastPeerHeartbeats = new Map()
+  })
+
+  // Replicates the heartbeat handler from core/src/service.ts
+  function handleHeartbeat(id: string, position: { x: number; y: number; z: number }) {
+    lastPeerHeartbeats.set(id, Date.now())
+    engine.onPeerPositionsUpdate([{ id, position: [position.x, position.y, position.z] }])
+  }
+
+  // Replicates the disconnect handler from core/src/service.ts (with the fix)
+  function handleDisconnect(id: string) {
+    lastPeerHeartbeats.delete(id)
+    engine.onPeerDisconnected(id)
+  }
+
+  // Replicates the heartbeat expiry loop from core/src/service.ts
+  function expireHeartbeats(expiredBefore: number) {
+    for (const [peerId, lastHeartbeat] of lastPeerHeartbeats) {
+      if (lastHeartbeat < expiredBefore) {
+        lastPeerHeartbeats.delete(peerId)
+        engine.onPeerDisconnected(peerId)
+      }
+    }
+  }
+
+  describe('when a peer disconnects and the heartbeat entry is cleaned up', () => {
+    beforeEach(async () => {
+      handleHeartbeat('peer1', { x: 0, y: 0, z: 0 })
+      await engine.flush()
+    })
+
+    it('should remove the heartbeat entry on disconnect', () => {
+      expect(lastPeerHeartbeats.has('peer1')).toBe(true)
+
+      handleDisconnect('peer1')
+
+      expect(lastPeerHeartbeats.has('peer1')).toBe(false)
+    })
+  })
+
+  describe('when a peer disconnects and reconnects quickly', () => {
+    beforeEach(async () => {
+      handleHeartbeat('peer1', { x: 0, y: 0, z: 0 })
+      await engine.flush()
+
+      // Peer disconnects
+      handleDisconnect('peer1')
+
+      // Peer reconnects and sends a heartbeat
+      handleHeartbeat('peer1', { x: 10, y: 0, z: 10 })
+      await engine.flush()
+    })
+
+    it('should have the peer in an island after reconnection', () => {
+      expect(engine.getIslands()).toHaveLength(1)
+      const peer = engine.getPeerData('peer1')
+      expect(peer).toBeDefined()
+      expect(peer!.islandId).toBeDefined()
+    })
+
+    it('should not disconnect the peer when old heartbeat would have expired', () => {
+      // Simulate expiry check — since the disconnect handler deleted the old entry
+      // and the new heartbeat created a fresh entry, this should NOT expire the peer
+      const now = Date.now()
+      expireHeartbeats(now - CHECK_HEARTBEAT_INTERVAL)
+
+      // The peer's new heartbeat should still be valid
+      expect(lastPeerHeartbeats.has('peer1')).toBe(true)
+      expect(engine.getPeerData('peer1')).toBeDefined()
+    })
+  })
+
+  describe('when a peer disconnects and reconnects without heartbeat cleanup (pre-fix behavior)', () => {
+    // This test demonstrates why the fix is needed
+    let lastPeerHeartbeatsNoCleanup: Map<string, number>
+
+    beforeEach(async () => {
+      lastPeerHeartbeatsNoCleanup = new Map()
+    })
+
+    // Pre-fix disconnect handler: does NOT clean up heartbeat entry
+    function handleDisconnectBroken(id: string) {
+      // Missing: lastPeerHeartbeatsNoCleanup.delete(id)
+      engine.onPeerDisconnected(id)
+    }
+
+    function handleHeartbeatNoCleanup(id: string, position: { x: number; y: number; z: number }) {
+      lastPeerHeartbeatsNoCleanup.set(id, Date.now())
+      engine.onPeerPositionsUpdate([{ id, position: [position.x, position.y, position.z] }])
+    }
+
+    it('should leave a stale heartbeat entry after disconnect', () => {
+      handleHeartbeatNoCleanup('peer1', { x: 0, y: 0, z: 0 })
+      handleDisconnectBroken('peer1')
+
+      expect(lastPeerHeartbeatsNoCleanup.has('peer1')).toBe(true)
+    })
+  })
+
+  describe('when heartbeat expiry runs and the peer has not sent heartbeats', () => {
+    beforeEach(async () => {
+      handleHeartbeat('peer1', { x: 0, y: 0, z: 0 })
+      await engine.flush()
+    })
+
+    it('should disconnect the peer when heartbeat expires', () => {
+      expect(engine.getPeerData('peer1')).toBeDefined()
+
+      // Simulate enough time passing
+      const farFuture = Date.now() + CHECK_HEARTBEAT_INTERVAL + 1000
+      expireHeartbeats(farFuture)
+
+      expect(lastPeerHeartbeats.has('peer1')).toBe(false)
+      expect(engine.getPeerData('peer1')).toBeUndefined()
+    })
+  })
+
+  describe('when heartbeat expiry runs and the peer is still active', () => {
+    beforeEach(async () => {
+      handleHeartbeat('peer1', { x: 0, y: 0, z: 0 })
+      await engine.flush()
+    })
+
+    it('should not disconnect the peer if the heartbeat is recent', () => {
+      const recentExpiry = Date.now() - CHECK_HEARTBEAT_INTERVAL
+      expireHeartbeats(recentExpiry)
+
+      expect(lastPeerHeartbeats.has('peer1')).toBe(true)
+      expect(engine.getPeerData('peer1')).toBeDefined()
+    })
+  })
+})

--- a/core/test/unit/service-prefered-island.spec.ts
+++ b/core/test/unit/service-prefered-island.spec.ts
@@ -1,0 +1,109 @@
+import { Engine, PeerPositionChange } from '../../src/types'
+import { createLogComponent } from '@well-known-components/logger'
+import { createTestMetricsComponent } from '@well-known-components/metrics'
+import { metricDeclarations } from '../../src/metrics'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { createArchipelagoEngine } from '../../src/adapters/engine'
+
+/**
+ * These tests verify the preferedIslandId handling, specifically the
+ * interaction between the 'preferedIslandId' in change semantics and
+ * how the core service maps desiredRoom to preferedIslandId.
+ */
+describe('preferedIslandId handling', () => {
+  let engine: Engine
+
+  beforeEach(async () => {
+    const config = createConfigComponent({ LOG_LEVEL: 'INFO' })
+    const logs = await createLogComponent({ config })
+    const metrics = createTestMetricsComponent(metricDeclarations)
+
+    engine = createArchipelagoEngine({
+      components: { logs, metrics },
+      joinDistance: 64,
+      leaveDistance: 80,
+      transport: {
+        name: 'test',
+        maxIslandSize: 200,
+        getConnectionStrings(userIds: string[], roomId: string): Promise<Record<string, string>> {
+          const connStrs: Record<string, string> = {}
+          for (const userId of userIds) {
+            connStrs[userId] = `test:${roomId}.${userId}`
+          }
+          return Promise.resolve(connStrs)
+        }
+      }
+    })
+  })
+
+  describe('when preferedIslandId key is present with undefined value', () => {
+    beforeEach(async () => {
+      engine.onPeerPositionsUpdate([
+        { id: '1', position: [0, 0, 0], preferedIslandId: 'target-island' }
+      ])
+      await engine.flush()
+
+      // This simulates what happened BEFORE the fix in service.ts:
+      // the heartbeat handler always included the key, even when desiredRoom was undefined
+      engine.onPeerPositionsUpdate([
+        { id: '1', position: [5, 0, 5], preferedIslandId: undefined }
+      ])
+      await engine.flush()
+    })
+
+    it('should clear the preferedIslandId because the key is present', () => {
+      const peer = engine.getPeerData('1')
+      expect(peer!.preferedIslandId).toBeUndefined()
+    })
+  })
+
+  describe('when preferedIslandId key is omitted entirely', () => {
+    beforeEach(async () => {
+      engine.onPeerPositionsUpdate([
+        { id: '1', position: [0, 0, 0], preferedIslandId: 'target-island' }
+      ])
+      await engine.flush()
+
+      // This simulates the FIXED service.ts behavior:
+      // when desiredRoom is undefined, the key is omitted from the change object
+      engine.onPeerPositionsUpdate([{ id: '1', position: [5, 0, 5] }])
+      await engine.flush()
+    })
+
+    it('should preserve the existing preferedIslandId', () => {
+      const peer = engine.getPeerData('1')
+      expect(peer!.preferedIslandId).toBe('target-island')
+    })
+  })
+
+  describe('when simulating the core service heartbeat handler (fixed behavior)', () => {
+    beforeEach(async () => {
+      engine.onPeerPositionsUpdate([
+        { id: 'peer1', position: [0, 0, 0], preferedIslandId: 'my-room' }
+      ])
+      await engine.flush()
+    })
+
+    it('should preserve preference across heartbeats without desiredRoom', () => {
+      // Simulate multiple heartbeats from the FIXED service handler:
+      // when desiredRoom is undefined, the key is omitted
+      for (let i = 0; i < 5; i++) {
+        const change: PeerPositionChange = { id: 'peer1', position: [i, 0, i] }
+        // Note: preferedIslandId key is NOT in the object
+        engine.onPeerPositionsUpdate([change])
+      }
+
+      const peer = engine.getPeerData('peer1')
+      expect(peer!.preferedIslandId).toBe('my-room')
+    })
+
+    it('should clear preference when a heartbeat explicitly sets a new desiredRoom', () => {
+      engine.onPeerPositionsUpdate([
+        { id: 'peer1', position: [5, 0, 5], preferedIslandId: 'other-room' }
+      ])
+
+      const peer = engine.getPeerData('peer1')
+      expect(peer!.preferedIslandId).toBe('other-room')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fix `lastPeerHeartbeats` not cleaned up on `peer.*.disconnect` / `peer.*.connect` NATS messages, causing stale entries that could spuriously disconnect a reconnected peer
- Fix heartbeat `position!` non-null assertion — replace with null guard that drops malformed heartbeats
- Fix `preferedIslandId` being cleared on every heartbeat because the service always included the key with `undefined` value instead of omitting it when `desiredRoom` is not set
- Add null-safe island lookup when publishing updates (defensive guard)

## Test plan
- [x] New `service-heartbeat.spec.ts` (6 tests): heartbeat cleanup on disconnect, reconnect safety, expiry behavior
- [x] New `service-prefered-island.spec.ts` (4 tests): key-present-with-undefined vs key-omitted semantics, preference persistence across heartbeats