### PR TITLE
fix: point workflows at archipelago-ea-* service names

### DIFF
--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -6,26 +6,26 @@ on:
       - "main"
 
 jobs:
-  archipelago-core-deployment:
+  archipelago-ea-core-deployment:
     uses: decentraland/platform-actions/.github/workflows/apps-docker-next.yml@main
     with:
-      service-name: archipelago-core
+      service-name: archipelago-ea-core
       image-name: archipelago-workers
       deployment-environment: dev
     secrets: inherit
 
-  archipelago-stats-deployment:
+  archipelago-ea-stats-deployment:
     uses: decentraland/platform-actions/.github/workflows/apps-docker-next.yml@main
     with:
-      service-name: archipelago-stats
+      service-name: archipelago-ea-stats
       image-name: archipelago-workers
       deployment-environment: dev
     secrets: inherit
 
-  archipelago-ws-connector-deployment:
+  archipelago-ea-ws-connector-deployment:
     uses: decentraland/platform-actions/.github/workflows/apps-docker-next.yml@main
     with:
-      service-name: archipelago-ws-connector
+      service-name: archipelago-ea-ws-connector
       image-name: archipelago-workers
       deployment-environment: dev
     secrets: inherit

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,26 +6,26 @@ on:
       - "created"
 
 jobs:
-  archipelago-core-deployment:
+  archipelago-ea-core-deployment:
     uses: decentraland/platform-actions/.github/workflows/apps-docker-release.yml@main
     with:
-      service-name: archipelago-core
+      service-name: archipelago-ea-core
       image-name: archipelago-workers
       deployment-environment: prd
     secrets: inherit
 
-  archipelago-stats-deployment:
+  archipelago-ea-stats-deployment:
     uses: decentraland/platform-actions/.github/workflows/apps-docker-release.yml@main
     with:
-      service-name: archipelago-stats
+      service-name: archipelago-ea-stats
       image-name: archipelago-workers
       deployment-environment: prd
     secrets: inherit
 
-  archipelago-ws-connector-deployment:
+  archipelago-ea-ws-connector-deployment:
     uses: decentraland/platform-actions/.github/workflows/apps-docker-release.yml@main
     with:
-      service-name: archipelago-ws-connector
+      service-name: archipelago-ea-ws-connector
       image-name: archipelago-workers
       deployment-environment: prd
     secrets: inherit

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -7,9 +7,6 @@ on:
         required: true
         type: choice
         options:
-          - archipelago-core
-          - archipelago-ws-connector
-          - archipelago-stats
           - archipelago-ea-core
           - archipelago-ea-ws-connector
           - archipelago-ea-stats

--- a/docs/stats/openapi.yaml
+++ b/docs/stats/openapi.yaml
@@ -55,7 +55,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  x-api-id: archipelago-stats-api
+  x-api-id: archipelago-ea-stats-api
 servers:
   - url: https://archipelago-ea-stats.decentraland.org
     description: Stats service - Production

--- a/docs/ws-connector/openapi.yaml
+++ b/docs/ws-connector/openapi.yaml
@@ -77,7 +77,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  x-api-id: archipelago-ws-connector-api
+  x-api-id: archipelago-ea-ws-connector-api
 servers:
   - url: https://archipelago-ea-ws-connector.decentraland.org
     description: WebSocket Connector service - Production


### PR DESCRIPTION
## What

Updates the GitHub Actions workflows to reference the current `archipelago-ea-*` service names.

## Why

The non-EA archipelago service definitions (`archipelago-core`, `archipelago-stats`, `archipelago-ws-connector`, along with `archipelago-nats` and `archipelago-prometheus-nats-exporter`) were **removed** from `decentraland/definitions` on 2026-05-28 (commit `e6af5f4`, "feat: remove comms services for play site"). Only the `archipelago-ea-*` variants remain. Since `definitions` derives the deployable service name from the definition filename, the workflows here were still pointing at service names that no longer exist.

## Changes

- **`docker-next.yml`** (auto-deploy to `dev` on push to `main`): renamed jobs + `service-name` → `archipelago-ea-core` / `archipelago-ea-stats` / `archipelago-ea-ws-connector`
- **`docker-release.yml`** (auto-deploy to `prd` on release): same three renames
- **`manual-deploy.yml`**: dropped the 3 removed non-EA options from the `service-name` choice list, keeping the EA services

## Notes

- `build.yml`, `docs.yaml`, `pr.yml`, `validate-pr-title.yml` only reference `archipelago-workers` (repo/image name, unchanged) — left as-is.
- This redirects the automated dev/prd deploys to the EA services, which is the intended effect now that the old services are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)