### PR TITLE
fix: use crypto-secure random for ws auth challenge nonce

### DIFF
--- a/ws-connector/src/controllers/handlers/ws-handler.ts
+++ b/ws-connector/src/controllers/handlers/ws-handler.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import {
   ClientPacket,
   Heartbeat,
@@ -144,7 +145,7 @@ export async function registerWsHandler(
               return
             }
 
-            const challengeToSign = 'dcl-' + Math.random().toString(36)
+            const challengeToSign = 'dcl-' + randomBytes(32).toString('hex')
             const previousWs = peersRegistry.getPeerWs(address)
             const alreadyConnected = !!previousWs
             logger.debug('Generating challenge', {


### PR DESCRIPTION
## What

The WebSocket auth handshake generated its challenge nonce with `'dcl-' + Math.random().toString(36)`. `Math.random()` is not cryptographically secure (predictable PRNG state) and yields low entropy. The challenge is the only anti-replay defense of the signed handshake, so a predictable/colliding nonce weakens replay protection for a captured `signedChallenge`.

## Change

Generate the challenge with `randomBytes(32).toString('hex')` from `node:crypto`.

## Verification

- `tsc --noEmit` clean on the ws-connector workspace
- eslint clean on changed file