### PR TITLE
fix: only evict ws registry entry when the closing socket owns it

### DIFF
--- a/ws-connector/src/adapters/peers-registry.ts
+++ b/ws-connector/src/adapters/peers-registry.ts
@@ -7,7 +7,7 @@ export type WsApp = {
 
 export type IPeersRegistryComponent = IBaseComponent & {
   onPeerConnected(id: string, ws: InternalWebSocket): void
-  onPeerDisconnected(id: string): void
+  onPeerDisconnected(id: string, ws: InternalWebSocket): void
   getPeerWs(id: string): InternalWebSocket | undefined
   getPeerCount(): number
   // Returns a point-in-time copy of the registry. Used by the ban sweep so
@@ -22,8 +22,13 @@ export async function createPeersRegistry(): Promise<IPeersRegistryComponent> {
     connectedPeers.set(id, ws)
   }
 
-  function onPeerDisconnected(id: string): void {
-    connectedPeers.delete(id)
+  function onPeerDisconnected(id: string, ws: InternalWebSocket): void {
+    // Only remove the entry if it still points to this socket. After a reconnect
+    // the previous socket closes later; without this guard its close would evict
+    // the new live socket from the registry, hiding it from the ban sweep.
+    if (connectedPeers.get(id) === ws) {
+      connectedPeers.delete(id)
+    }
   }
 
   function getPeerWs(id: string): InternalWebSocket | undefined {

--- a/ws-connector/src/controllers/handlers/ws-handler.ts
+++ b/ws-connector/src/controllers/handlers/ws-handler.ts
@@ -292,7 +292,7 @@ export async function registerWsHandler(
         data.timeout = undefined
       }
       if (data.address) {
-        peersRegistry.onPeerDisconnected(data.address)
+        peersRegistry.onPeerDisconnected(data.address, ws)
         nats.publish(`peer.${data.address}.disconnect`)
       }
     }


### PR DESCRIPTION
## What

`peersRegistry.onPeerDisconnected(address)` deleted the registry entry for an address unconditionally, and the WebSocket `close` handler called it without checking that the socket being closed was the one currently registered for that address.

On reconnect, the handshake replaces the old socket with the new one (`onPeerConnected(address, newWs)`). When the **old** socket's `close` fires shortly after, it would delete the registry entry that now points to the **new, live** socket. The live peer then disappears from `snapshot()`, so the ban sweep no longer sees it — a banned user who reconnects within that window evades the kick (and future kicks can't find the socket).

## Change

- `onPeerDisconnected(id, ws)` now only deletes the entry when `connectedPeers.get(id) === ws`, so a stale socket's close can't evict the current one.
- The `close` handler passes its `ws`.

## Verification

- `tsc --noEmit` clean on the ws-connector workspace; eslint clean on the changed files.
- Unit suites `ws-handler.spec.ts` + `ban-sweep.spec.ts`: 26 passing.