### PR TITLE
chore: pin node 24 base image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG RUN
 # glibc 2.36). @dcl/uws-http-server bundles uWebSockets.js, whose prebuilt binaries
 # are glibc-only and require GLIBC >= 2.38: they fail to load on bookworm (so
 # `yarn test` below would crash) and segfault on alpine (musl), even with gcompat.
-FROM node:24-trixie-slim as builderenv
+FROM node:24-trixie-slim@sha256:287c662bed62f3c7b68ea68544814eaff9d7ed2254d2fc9627f2df5957bb7401 as builderenv
 
 WORKDIR /app
 
@@ -30,7 +30,7 @@ RUN yarn install --prod --frozen-lockfile
 ########################## END OF BUILD STAGE ##########################
 
 # Debian Trixie (glibc 2.41) — required by uWebSockets.js, see note on the builder stage above.
-FROM node:24-trixie-slim
+FROM node:24-trixie-slim@sha256:287c662bed62f3c7b68ea68544814eaff9d7ed2254d2fc9627f2df5957bb7401
 
 RUN apt-get update
 RUN apt-get upgrade -y


### PR DESCRIPTION
Sets the base image to `node:24-trixie-slim@sha256:287c662bed62f3c7b68ea68544814eaff9d7ed2254d2fc9627f2df5957bb7401` (was `node:24-trixie-slim`) and pins it to an immutable sha256 digest for reproducible builds. Keeps the Debian **trixie-slim** variant on purpose — native deps need glibc, not alpine musl.